### PR TITLE
feat: make claude command configurable via config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ require("claude-code").setup({
   git = {
     use_git_root = true,     -- Set CWD to git root when opening Claude Code (if in git project)
   },
+  -- Command settings
+  command = "claude",        -- Command used to launch Claude Code
   -- Keymaps
   keymaps = {
     toggle = {

--- a/lua/claude-code/config.lua
+++ b/lua/claude-code/config.lua
@@ -41,6 +41,7 @@ local M = {}
 -- @field window ClaudeCodeWindow Terminal window settings
 -- @field refresh ClaudeCodeRefresh File refresh settings
 -- @field git ClaudeCodeGit Git integration settings
+-- @field command string Command used to launch Claude Code
 -- @field keymaps ClaudeCodeKeymaps Keymaps configuration
 
 --- Default configuration options
@@ -65,6 +66,8 @@ M.default_config = {
   git = {
     use_git_root = true, -- Set CWD to git root when opening Claude Code (if in git project)
   },
+  -- Command settings
+  command = 'claude', -- Command used to launch Claude Code
   -- Keymaps
   keymaps = {
     toggle = {
@@ -138,6 +141,11 @@ local function validate_config(config)
 
   if type(config.git.use_git_root) ~= 'boolean' then
     return false, 'git.use_git_root must be a boolean'
+  end
+
+  -- Validate command settings
+  if type(config.command) ~= 'string' then
+    return false, 'command must be a string'
   end
 
   -- Validate keymaps settings

--- a/lua/claude-code/terminal.lua
+++ b/lua/claude-code/terminal.lua
@@ -62,11 +62,11 @@ function M.toggle(claude_code, config, git)
     vim.cmd('resize ' .. math.floor(vim.o.lines * config.window.height_ratio))
 
     -- Determine if we should use the git root directory
-    local cmd = 'terminal claude'
+    local cmd = 'terminal ' .. config.command
     if config.git and config.git.use_git_root then
       local git_root = git.get_git_root()
       if git_root then
-        cmd = 'terminal claude --cwd ' .. git_root
+        cmd = 'terminal ' .. config.command .. ' --cwd ' .. git_root
       end
     end
 

--- a/tests/spec/terminal_spec.lua
+++ b/tests/spec/terminal_spec.lua
@@ -67,6 +67,7 @@ describe('terminal module', function()
     
     -- Setup test objects
     config = {
+      command = 'claude',
       window = {
         position = 'botright',
         height_ratio = 0.5,


### PR DESCRIPTION
Allows users to customize the command used to launch Claude Code through the config.command option. Default remains 'claude' for backwards compatibility.

# Pull Request

## Description

Please provide a clear description of what this PR does and why it should be merged.

## Type of Change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

Please check all that apply:

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested with the actual Claude Code CLI tool
- [ ] I have tested in different environments (if applicable)

## Screenshots (if applicable)

Add screenshots to help explain your changes if they include visual elements.

## Additional Notes

Add any other context about the PR here.