### PR TITLE
fix: improve vertical split behavior for claude terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- New `split_ratio` config option to replace `height_ratio` for better handling of both horizontal and vertical splits
+
+### Fixed
+- Fixed vertical split behavior when the window position is set to a vertical split command
+
 ## [0.4.2] - 2025-03-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The plugin can be configured by passing a table to the `setup` function. Here's 
 require("claude-code").setup({
   -- Terminal window settings
   window = {
-    height_ratio = 0.3,     -- Percentage of screen height for the terminal window
-    position = "botright",  -- Position of the window: "botright", "topleft", etc.
+    split_ratio = 0.3,      -- Percentage of screen for the terminal window (height for horizontal, width for vertical splits)
+    position = "botright",  -- Position of the window: "botright", "topleft", "vertical", "rightbelow vsplit", etc.
     enter_insert = true,    -- Whether to enter insert mode when opening Claude Code
     hide_numbers = true,    -- Hide line numbers in the terminal window
     hide_signcolumn = true, -- Hide the sign column in the terminal window

--- a/doc/claude-code.txt
+++ b/doc/claude-code.txt
@@ -90,8 +90,8 @@ default configuration:
   require("claude-code").setup({
     -- Terminal window settings
     window = {
-      height_ratio = 0.3,     -- Percentage of screen height for the terminal window
-      position = "botright",  -- Position of the window: "botright", "topleft", etc.
+      split_ratio = 0.3,      -- Percentage of screen for the terminal window (height or width)
+      position = "botright",  -- Position of the window: "botright", "topleft", "vertical", "vsplit", etc.
       enter_insert = true,    -- Whether to enter insert mode when opening Claude Code
       hide_numbers = true,    -- Hide line numbers in the terminal window
       hide_signcolumn = true, -- Hide the sign column in the terminal window

--- a/tests/spec/config_spec.lua
+++ b/tests/spec/config_spec.lua
@@ -15,11 +15,11 @@ describe('config', function()
     it('should merge user config with default config', function()
       local user_config = {
         window = {
-          height_ratio = 0.5,
+          split_ratio = 0.5,
         },
       }
       local result = config.parse_config(user_config, true) -- silent mode
-      assert.are.equal(0.5, result.window.height_ratio)
+      assert.are.equal(0.5, result.window.split_ratio)
 
       -- Other values should be set to defaults
       assert.are.equal('botright', result.window.position)
@@ -27,16 +27,31 @@ describe('config', function()
     end)
 
     it('should validate config values', function()
-      -- This config has an invalid height_ratio (should be between 0 and 1)
+      -- This config has an invalid split_ratio (should be between 0 and 1)
       local invalid_config = {
         window = {
-          height_ratio = 2,
+          split_ratio = 2,
         },
       }
 
       -- When validation fails, it should return the default config
       local result = config.parse_config(invalid_config, true) -- silent mode
-      assert.are.equal(config.default_config.window.height_ratio, result.window.height_ratio)
+      assert.are.equal(config.default_config.window.split_ratio, result.window.split_ratio)
+    end)
+    
+    it('should maintain backward compatibility with height_ratio', function()
+      -- Config using the legacy height_ratio instead of split_ratio
+      local legacy_config = {
+        window = {
+          height_ratio = 0.7,
+          -- split_ratio not specified
+        },
+      }
+
+      local result = config.parse_config(legacy_config, true) -- silent mode
+      
+      -- split_ratio should be set to the height_ratio value
+      assert.are.equal(0.7, result.window.split_ratio)
     end)
   end)
 end)

--- a/tests/spec/terminal_spec.lua
+++ b/tests/spec/terminal_spec.lua
@@ -70,7 +70,7 @@ describe('terminal module', function()
       command = 'claude',
       window = {
         position = 'botright',
-        height_ratio = 0.5,
+        split_ratio = 0.5,
         enter_insert = true,
         hide_numbers = true,
         hide_signcolumn = true,


### PR DESCRIPTION
# Pull Request

## Description

Previously the window split command resized the current editor window rather than the claude window. This led to a weird behavior where asking for a vertical split made the window much shorter.

This change fixes this by:
1. Adding a unified split_ratio config option (with backward compatibility for height_ratio)
2. Properly detecting vertical splits via window position
3. Applying the appropriate resize command for each split type

## Type of Change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

Please check all that apply:

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested with the actual Claude Code CLI tool
- [x] I have tested in different environments (if applicable)

## Screenshots (if applicable)

using config:

```lua
{
    command = "/opt/dev/bin/dev claude",
    window = {
          width_ration = 0.4,
          position = "vertical rightbelow"
      }
   }
}
```

Note where the cmdline is located - approximately 40% of the way "down" even though I created a vertical split.

<img width="2672" alt="Screenshot 2025-03-29 at 10 35 09 AM" src="https://github.com/user-attachments/assets/e24f8ddd-1c78-464d-84ae-72546e435137" />

![Screenshot 2025-03-29 at 10 35 37 AM](https://github.com/user-attachments/assets/f9367e0f-4c0e-4ea8-80db-dc9dab516e9d)


Add screenshots to help explain your changes if they include visual elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a versatile configuration option for terminal window sizing that now supports both horizontal and vertical splits.
- **Bug Fixes**
	- Resolved an issue with vertical split behavior when positioning the terminal window.
- **Documentation**
	- Updated configuration guidelines to reflect the new split ratio and expanded available window position options for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->