### PR TITLE
Add support for command variants and arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This plugin was built entirely with Claude Code in a Neovim terminal, and then i
 ## Features
 
 - 🚀 Toggle Claude Code in a terminal window with a single key press
+- 🧠 Support for command-line arguments like `--continue` and custom variants
 - 🔄 Automatically detect and reload files modified by Claude Code
 - ⚡ Real-time buffer updates when files are changed externally
 - 📱 Customizable window position and size
@@ -114,11 +115,24 @@ require("claude-code").setup({
   },
   -- Command settings
   command = "claude",        -- Command used to launch Claude Code
+  -- Command variants
+  command_variants = {
+    -- Conversation management
+    continue = "--continue", -- Resume the most recent conversation
+    resume = "--resume",     -- Display an interactive conversation picker
+    
+    -- Output options
+    verbose = "--verbose",   -- Enable verbose logging with full turn-by-turn output
+  },
   -- Keymaps
   keymaps = {
     toggle = {
       normal = "<C-,>",       -- Normal mode keymap for toggling Claude Code, false to disable
       terminal = "<C-,>",     -- Terminal mode keymap for toggling Claude Code, false to disable
+      variants = {
+        continue = "<leader>cC", -- Normal mode keymap for Claude Code with continue flag
+        verbose = "<leader>cV",  -- Normal mode keymap for Claude Code with verbose flag
+      },
     },
     window_navigation = true, -- Enable window navigation keymaps (<C-h/j/k/l>)
     scrolling = true,         -- Enable scrolling keymaps (<C-f/b>) for page up/down
@@ -145,7 +159,20 @@ vim.keymap.set('n', '<leader>cc', '<cmd>ClaudeCode<CR>', { desc = 'Toggle Claude
 
 ### Commands
 
+Basic command:
+
 - `:ClaudeCode` - Toggle the Claude Code terminal window
+
+Conversation management commands:
+
+- `:ClaudeCodeContinue` - Resume the most recent conversation
+- `:ClaudeCodeResume` - Display an interactive conversation picker
+
+Output options command:
+
+- `:ClaudeCodeVerbose` - Enable verbose logging with full turn-by-turn output
+
+Note: Commands are automatically generated for each entry in your `command_variants` configuration.
 
 ### Key Mappings
 
@@ -153,6 +180,11 @@ Default key mappings:
 
 - `<leader>ac` - Toggle Claude Code terminal window (normal mode)
 - `<C-,>` - Toggle Claude Code terminal window (both normal and terminal modes)
+
+Variant mode mappings (if configured):
+
+- `<leader>cC` - Toggle Claude Code with --continue flag
+- `<leader>cV` - Toggle Claude Code with --verbose flag
 
 Additionally, when in the Claude Code terminal:
 

--- a/doc/claude-code.txt
+++ b/doc/claude-code.txt
@@ -109,11 +109,24 @@ default configuration:
     },
     -- Command settings
     command = "claude",        -- Command used to launch Claude Code (do not include --cwd)
+    -- Command variants
+    command_variants = {
+      -- Conversation management
+      continue = "--continue", -- Resume the most recent conversation
+      resume = "--resume",     -- Display an interactive conversation picker
+      
+      -- Output options
+      verbose = "--verbose",   -- Enable verbose logging with full turn-by-turn output
+    },
     -- Keymaps
     keymaps = {
       toggle = {
         normal = "<leader>ac",  -- Normal mode keymap for toggling Claude Code
         terminal = "<C-o>",     -- Terminal mode keymap for toggling Claude Code
+        variants = {
+          continue = "<leader>cC", -- Normal mode keymap for Claude Code with continue flag
+          verbose = "<leader>cV",  -- Normal mode keymap for Claude Code with verbose flag
+        },
       }
     }
   })
@@ -125,6 +138,19 @@ default configuration:
 :ClaudeCode                                                       *:ClaudeCode*
     Toggle the Claude Code terminal window.
 
+Conversation Management Commands:
+:ClaudeCodeContinue                                           *:ClaudeCodeContinue*
+    Toggle Claude Code with the --continue flag to resume the most recent conversation.
+
+:ClaudeCodeResume                                             *:ClaudeCodeResume*
+    Toggle Claude Code with the --resume flag to display an interactive conversation picker.
+
+Output Options Commands:
+:ClaudeCodeVerbose                                           *:ClaudeCodeVerbose*
+    Toggle Claude Code with the --verbose flag for full turn-by-turn output.
+
+Note: Commands are automatically generated for each entry in your command_variants configuration.
+
 ==============================================================================
 6. MAPPINGS                                                *claude-code-mappings*
 
@@ -132,6 +158,11 @@ Default key mappings:
 
   <leader>ac   Toggle Claude Code terminal window (normal mode)
   <C-.>        Toggle Claude Code terminal window (both normal and terminal modes)
+  
+Variant mode mappings (if configured):
+
+  <leader>cC   Toggle Claude Code with --continue flag
+  <leader>cV   Toggle Claude Code with --verbose flag
 
 Additionally, when in the Claude Code terminal:
 

--- a/lua/claude-code/commands.lua
+++ b/lua/claude-code/commands.lua
@@ -17,6 +17,19 @@ function M.register_commands(claude_code)
     claude_code.toggle()
   end, { desc = 'Toggle Claude Code terminal' })
 
+  -- Create commands for each command variant
+  for variant_name, variant_args in pairs(claude_code.config.command_variants) do
+    if variant_args ~= false then
+      -- Convert variant name to PascalCase for command name (e.g., "continue" -> "Continue")
+      local capitalized_name = variant_name:gsub('^%l', string.upper)
+      local cmd_name = 'ClaudeCode' .. capitalized_name
+
+      vim.api.nvim_create_user_command(cmd_name, function()
+        claude_code.toggle_with_variant(variant_name)
+      end, { desc = 'Toggle Claude Code terminal with ' .. variant_name .. ' option' })
+    end
+  end
+
   -- Add version command
   vim.api.nvim_create_user_command('ClaudeCodeVersion', function()
     vim.notify('Claude Code version: ' .. claude_code.version(), vim.log.levels.INFO)

--- a/lua/claude-code/init.lua
+++ b/lua/claude-code/init.lua
@@ -55,6 +55,32 @@ function M.toggle()
   end
 end
 
+--- Toggle the Claude Code terminal window with a specific command variant
+--- @param variant_name string The name of the command variant to use
+function M.toggle_with_variant(variant_name)
+  if not variant_name or not M.config.command_variants[variant_name] then
+    -- If variant doesn't exist, fall back to regular toggle
+    return M.toggle()
+  end
+
+  -- Store the original command
+  local original_command = M.config.command
+
+  -- Set the command with the variant args
+  M.config.command = original_command .. ' ' .. M.config.command_variants[variant_name]
+
+  -- Call the toggle function with the modified command
+  terminal.toggle(M, M.config, git)
+
+  -- Set up terminal navigation keymaps after toggling
+  if M.claude_code.bufnr and vim.api.nvim_buf_is_valid(M.claude_code.bufnr) then
+    keymaps.setup_terminal_navigation(M, M.config)
+  end
+
+  -- Restore the original command
+  M.config.command = original_command
+end
+
 --- Get the current version of the plugin
 --- @return string version Current version string
 function M.get_version()

--- a/lua/claude-code/keymaps.lua
+++ b/lua/claude-code/keymaps.lua
@@ -34,6 +34,24 @@ function M.register_keymaps(claude_code, config)
     )
   end
 
+  -- Register variant keymaps if configured
+  if config.keymaps.toggle.variants then
+    for variant_name, keymap in pairs(config.keymaps.toggle.variants) do
+      if keymap then
+        -- Convert variant name to PascalCase for command name (e.g., "continue" -> "Continue")
+        local capitalized_name = variant_name:gsub('^%l', string.upper)
+        local cmd_name = 'ClaudeCode' .. capitalized_name
+
+        vim.api.nvim_set_keymap(
+          'n',
+          keymap,
+          string.format([[<cmd>%s<CR>]], cmd_name),
+          vim.tbl_extend('force', map_opts, { desc = 'Claude Code: ' .. capitalized_name })
+        )
+      end
+    end
+  end
+
   -- Register with which-key if it's available
   vim.defer_fn(function()
     local status_ok, which_key = pcall(require, 'which-key')
@@ -49,6 +67,19 @@ function M.register_keymaps(claude_code, config)
           mode = 't',
           { config.keymaps.toggle.terminal, desc = 'Claude Code: Toggle', icon = '🤖' },
         }
+      end
+
+      -- Register variant keymaps with which-key
+      if config.keymaps.toggle.variants then
+        for variant_name, keymap in pairs(config.keymaps.toggle.variants) do
+          if keymap then
+            local capitalized_name = variant_name:gsub('^%l', string.upper)
+            which_key.add {
+              mode = 'n',
+              { keymap, desc = 'Claude Code: ' .. capitalized_name, icon = '🤖' },
+            }
+          end
+        end
       end
     end
   end, 100)


### PR DESCRIPTION
Tested on my local neovim installation and works a treat! (And use, I did use Claude Code to help build this solution)

This PR adds support for different Claude Code command variants:

## Features

- Configure command-line arguments for modes like --continue and --resume
- Generate commands for each variant (e.g. :ClaudeCodeContinue)
- Add configurable keymaps for each variant
- Update documentation with the new options

## Use Cases

This allows users to easily access conversation history and other Claude CLI modes directly from Neovim. For example:

-  - Resume the most recent conversation
-  - Display an interactive conversation picker
-  - Enable verbose logging with turn-by-turn output

The implementation is modular and allows for easy addition of more command variants in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for command-line argument variants (continue, resume, verbose) to enhance control of Claude Code.
  - Introduced new user commands (:ClaudeCodeContinue, :ClaudeCodeResume, :ClaudeCodeVerbose) for variant-specific toggling.
  - Added configurable key mappings for toggling Claude Code with these command variants.

- **Documentation**
  - Updated README and plugin documentation to include details on command variants, key mappings, and usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->