### PR TITLE
feat: add floating window support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `split_ratio` config option to replace `height_ratio` for better handling of both horizontal and vertical splits
+- Support for floating windows with `position = "float"` configuration
+- Comprehensive floating window configuration options including dimensions, position, and border styles
 
 ### Fixed
 - Fixed vertical split behavior when the window position is set to a vertical split command

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This plugin was built entirely with Claude Code in a Neovim terminal, and then i
 - 🧠 Support for command-line arguments like `--continue` and custom variants
 - 🔄 Automatically detect and reload files modified by Claude Code
 - ⚡ Real-time buffer updates when files are changed externally
-- 📱 Customizable window position and size
+- 📱 Customizable window position and size (including floating windows)
 - 🤖 Integration with which-key (if available)
 - 📂 Automatically uses git project root as working directory (when available)
 - 🧩 Modular and maintainable code structure
@@ -97,10 +97,20 @@ require("claude-code").setup({
   -- Terminal window settings
   window = {
     split_ratio = 0.3,      -- Percentage of screen for the terminal window (height for horizontal, width for vertical splits)
-    position = "botright",  -- Position of the window: "botright", "topleft", "vertical", "rightbelow vsplit", etc.
+    position = "botright",  -- Position of the window: "botright", "topleft", "vertical", "float", etc.
     enter_insert = true,    -- Whether to enter insert mode when opening Claude Code
     hide_numbers = true,    -- Hide line numbers in the terminal window
     hide_signcolumn = true, -- Hide the sign column in the terminal window
+    
+    -- Floating window configuration (only applies when position = "float")
+    float = {
+      width = "80%",        -- Width: number of columns or percentage string
+      height = "80%",       -- Height: number of rows or percentage string
+      row = "center",       -- Row position: number, "center", or percentage string
+      col = "center",       -- Column position: number, "center", or percentage string
+      relative = "editor",  -- Relative to: "editor" or "cursor"
+      border = "rounded",   -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
+    },
   },
   -- File refresh settings
   refresh = {
@@ -198,6 +208,26 @@ Additionally, when in the Claude Code terminal:
 Note: After scrolling with `<C-f>` or `<C-b>`, you'll need to press the `i` key to re-enter insert mode so you can continue typing to Claude Code.
 
 When Claude Code modifies files that are open in Neovim, they'll be automatically reloaded.
+
+### Floating Window Example
+
+To use Claude Code in a floating window:
+
+```lua
+require("claude-code").setup({
+  window = {
+    position = "float",
+    float = {
+      width = "90%",      -- Take up 90% of the editor width
+      height = "90%",     -- Take up 90% of the editor height
+      row = "center",     -- Center vertically
+      col = "center",     -- Center horizontally
+      relative = "editor",
+      border = "double",  -- Use double border style
+    },
+  },
+})
+```
 
 ## How it Works
 

--- a/doc/claude-code.txt
+++ b/doc/claude-code.txt
@@ -91,11 +91,21 @@ default configuration:
     -- Terminal window settings
     window = {
       split_ratio = 0.3,      -- Percentage of screen for the terminal window (height or width)
-      position = "botright",  -- Position of the window: "botright", "topleft", "vertical", "vsplit", etc.
+      position = "botright",  -- Position of the window: "botright", "topleft", "vertical", "float", etc.
       enter_insert = true,    -- Whether to enter insert mode when opening Claude Code
       start_in_normal_mode = false, -- Whether to start in normal mode instead of insert mode
       hide_numbers = true,    -- Hide line numbers in the terminal window
       hide_signcolumn = true, -- Hide the sign column in the terminal window
+      
+      -- Floating window configuration (only applies when position = "float")
+      float = {
+        width = "80%",        -- Width: number of columns or percentage string
+        height = "80%",       -- Height: number of rows or percentage string
+        row = "center",       -- Row position: number, "center", or percentage string
+        col = "center",       -- Column position: number, "center", or percentage string
+        relative = "editor",  -- Relative to: "editor" or "cursor"
+        border = "rounded",   -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
+      },
     },
     -- File refresh settings
     refresh = {

--- a/lua/claude-code/config.lua
+++ b/lua/claude-code/config.lua
@@ -9,11 +9,18 @@ local M = {}
 --- ClaudeCodeWindow class for window configuration
 -- @table ClaudeCodeWindow
 -- @field split_ratio number Percentage of screen for the terminal window (height for horizontal, width for vertical splits)
--- @field position string Position of the window: "botright", "topleft", "vertical", etc.
+-- @field position string Position of the window: "botright", "topleft", "vertical", "float" etc.
 -- @field enter_insert boolean Whether to enter insert mode when opening Claude Code
 -- @field start_in_normal_mode boolean Whether to start in normal mode instead of insert mode when opening Claude Code
 -- @field hide_numbers boolean Hide line numbers in the terminal window
 -- @field hide_signcolumn boolean Hide the sign column in the terminal window
+-- @field float table|nil Floating window configuration (only used when position is "float")
+-- @field float.width number|string Width of floating window (number: columns, string: percentage like "80%")
+-- @field float.height number|string Height of floating window (number: rows, string: percentage like "80%")
+-- @field float.row number|string|nil Row position (number: absolute, string: "center" or percentage)
+-- @field float.col number|string|nil Column position (number: absolute, string: "center" or percentage)
+-- @field float.border string Border style: "none", "single", "double", "rounded", "solid", "shadow", or array
+-- @field float.relative string Relative positioning: "editor" or "cursor"
 
 --- ClaudeCodeRefresh class for file refresh configuration
 -- @table ClaudeCodeRefresh
@@ -62,11 +69,20 @@ M.default_config = {
   window = {
     split_ratio = 0.3, -- Percentage of screen for the terminal window (height or width)
     height_ratio = 0.3, -- DEPRECATED: Use split_ratio instead
-    position = 'botright', -- Position of the window: "botright", "topleft", "vertical", etc.
+    position = 'botright', -- Position of the window: "botright", "topleft", "vertical", "float", etc.
     enter_insert = true, -- Whether to enter insert mode when opening Claude Code
     start_in_normal_mode = false, -- Whether to start in normal mode instead of insert mode
     hide_numbers = true, -- Hide line numbers in the terminal window
     hide_signcolumn = true, -- Hide the sign column in the terminal window
+    -- Default floating window configuration
+    float = {
+      width = '80%', -- Width as percentage of editor
+      height = '80%', -- Height as percentage of editor
+      row = 'center', -- Center vertically
+      col = 'center', -- Center horizontally
+      relative = 'editor', -- Position relative to editor
+      border = 'rounded', -- Border style
+    },
   },
   -- File refresh settings
   refresh = {
@@ -141,6 +157,71 @@ local function validate_config(config)
 
   if type(config.window.hide_signcolumn) ~= 'boolean' then
     return false, 'window.hide_signcolumn must be a boolean'
+  end
+
+  -- Validate float configuration if position is "float"
+  if config.window.position == 'float' then
+    if type(config.window.float) ~= 'table' then
+      return false, 'window.float must be a table when position is "float"'
+    end
+
+    -- Validate width (can be number or percentage string)
+    if type(config.window.float.width) == 'string' then
+      if not config.window.float.width:match('^%d+%%$') then
+        return false, 'window.float.width must be a number or percentage (e.g., "80%")'
+      end
+    elseif type(config.window.float.width) ~= 'number' or config.window.float.width <= 0 then
+      return false, 'window.float.width must be a positive number or percentage string'
+    end
+
+    -- Validate height (can be number or percentage string)
+    if type(config.window.float.height) == 'string' then
+      if not config.window.float.height:match('^%d+%%$') then
+        return false, 'window.float.height must be a number or percentage (e.g., "80%")'
+      end
+    elseif type(config.window.float.height) ~= 'number' or config.window.float.height <= 0 then
+      return false, 'window.float.height must be a positive number or percentage string'
+    end
+
+    -- Validate relative (must be "editor" or "cursor")
+    if config.window.float.relative ~= 'editor' and config.window.float.relative ~= 'cursor' then
+      return false, 'window.float.relative must be "editor" or "cursor"'
+    end
+
+    -- Validate border (must be valid border style)
+    local valid_borders = { 'none', 'single', 'double', 'rounded', 'solid', 'shadow' }
+    local is_valid_border = false
+    for _, border in ipairs(valid_borders) do
+      if config.window.float.border == border then
+        is_valid_border = true
+        break
+      end
+    end
+    -- Also allow array borders
+    if not is_valid_border and type(config.window.float.border) ~= 'table' then
+      return false, 'window.float.border must be one of: none, single, double, rounded, solid, shadow, or an array'
+    end
+
+    -- Validate row and col if they exist
+    if config.window.float.row ~= nil then
+      if type(config.window.float.row) == 'string' and config.window.float.row ~= 'center' then
+        if not config.window.float.row:match('^%d+%%$') then
+          return false, 'window.float.row must be a number, "center", or percentage string'
+        end
+      elseif type(config.window.float.row) ~= 'number' and config.window.float.row ~= 'center' then
+        return false, 'window.float.row must be a number, "center", or percentage string'
+      end
+    end
+
+    if config.window.float.col ~= nil then
+      if type(config.window.float.col) == 'string' and config.window.float.col ~= 'center' then
+        if not config.window.float.col:match('^%d+%%$') then
+          return false, 'window.float.col must be a number, "center", or percentage string'
+        end
+      elseif type(config.window.float.col) ~= 'number' and config.window.float.col ~= 'center' then
+        return false, 'window.float.col must be a number, "center", or percentage string'
+      end
+    end
   end
 
   -- Validate refresh settings
@@ -257,6 +338,11 @@ function M.parse_config(user_config, silent)
   end
 
   local config = vim.tbl_deep_extend('force', {}, M.default_config, user_config or {})
+
+  -- If position is float and no float config provided, use default float config
+  if config.window.position == 'float' and not (user_config and user_config.window and user_config.window.float) then
+    config.window.float = vim.deepcopy(M.default_config.window.float)
+  end
 
   local valid, err = validate_config(config)
   if not valid then

--- a/lua/claude-code/terminal.lua
+++ b/lua/claude-code/terminal.lua
@@ -89,8 +89,8 @@ end
 local function create_split(position, config, existing_bufnr)
   -- Handle floating window
   if position == 'float' then
-    create_float(config, existing_bufnr)
-    return
+    local win_id = create_float(config, existing_bufnr)
+    return win_id
   end
 
   local is_vertical = position:match('vsplit') or position:match('vertical')

--- a/tests/spec/config_spec.lua
+++ b/tests/spec/config_spec.lua
@@ -53,5 +53,85 @@ describe('config', function()
       -- split_ratio should be set to the height_ratio value
       assert.are.equal(0.7, result.window.split_ratio)
     end)
+
+    it('should accept float configuration when position is float', function()
+      local float_config = {
+        window = {
+          position = 'float',
+          float = {
+            width = 80,
+            height = 20,
+            relative = 'editor',
+            border = 'rounded',
+          },
+        },
+      }
+
+      local result = config.parse_config(float_config, true) -- silent mode
+      
+      assert.are.equal('float', result.window.position)
+      assert.are.equal(80, result.window.float.width)
+      assert.are.equal(20, result.window.float.height)
+      assert.are.equal('editor', result.window.float.relative)
+      assert.are.equal('rounded', result.window.float.border)
+    end)
+
+    it('should accept float with percentage dimensions', function()
+      local float_config = {
+        window = {
+          position = 'float',
+          float = {
+            width = '80%',
+            height = '50%',
+            relative = 'editor',
+          },
+        },
+      }
+
+      local result = config.parse_config(float_config, true) -- silent mode
+      
+      assert.are.equal('80%', result.window.float.width)
+      assert.are.equal('50%', result.window.float.height)
+    end)
+
+    it('should accept float with center positioning', function()
+      local float_config = {
+        window = {
+          position = 'float',
+          float = {
+            width = 60,
+            height = 20,
+            row = 'center',
+            col = 'center',
+            relative = 'editor',
+          },
+        },
+      }
+
+      local result = config.parse_config(float_config, true) -- silent mode
+      
+      assert.are.equal('center', result.window.float.row)
+      assert.are.equal('center', result.window.float.col)
+    end)
+
+    it('should provide default float configuration', function()
+      local float_config = {
+        window = {
+          position = 'float',
+          -- No float config provided
+        },
+      }
+
+      local result = config.parse_config(float_config, true) -- silent mode
+      
+      -- Should have default float configuration
+      assert.is_not_nil(result.window.float)
+      assert.are.equal('80%', result.window.float.width)
+      assert.are.equal('80%', result.window.float.height)
+      assert.are.equal('center', result.window.float.row)
+      assert.are.equal('center', result.window.float.col)
+      assert.are.equal('editor', result.window.float.relative)
+      assert.are.equal('rounded', result.window.float.border)
+    end)
   end)
 end)

--- a/tests/spec/config_validation_spec.lua
+++ b/tests/spec/config_validation_spec.lua
@@ -31,6 +31,56 @@ describe('config validation', function()
       local result = config.parse_config(invalid_config, true) -- silent mode
       assert.are.equal(config.default_config.window.hide_numbers, result.window.hide_numbers)
     end)
+
+    it('should validate float configuration when position is float', function()
+      local invalid_config = vim.deepcopy(config.default_config)
+      invalid_config.window.position = 'float'
+      invalid_config.window.float = 'invalid' -- Should be a table
+
+      local result = config.parse_config(invalid_config, true) -- silent mode
+      -- When validation fails, should return default config
+      assert.are.equal(config.default_config.window.position, result.window.position)
+    end)
+
+    it('should validate float.width can be a number or percentage string', function()
+      local invalid_config = vim.deepcopy(config.default_config)
+      invalid_config.window.position = 'float'
+      invalid_config.window.float = {
+        width = true, -- Invalid - boolean
+        height = 20,
+        relative = 'editor'
+      }
+
+      local result = config.parse_config(invalid_config, true) -- silent mode
+      assert.are.equal(config.default_config.window.position, result.window.position)
+    end)
+
+    it('should validate float.relative must be "editor" or "cursor"', function()
+      local invalid_config = vim.deepcopy(config.default_config)
+      invalid_config.window.position = 'float'
+      invalid_config.window.float = {
+        width = 80,
+        height = 20,
+        relative = 'window' -- Invalid option
+      }
+
+      local result = config.parse_config(invalid_config, true) -- silent mode
+      assert.are.equal(config.default_config.window.position, result.window.position)
+    end)
+
+    it('should validate float.border must be a valid border style', function()
+      local invalid_config = vim.deepcopy(config.default_config)
+      invalid_config.window.position = 'float'
+      invalid_config.window.float = {
+        width = 80,
+        height = 20,
+        relative = 'editor',
+        border = 'invalid' -- Invalid border style
+      }
+
+      local result = config.parse_config(invalid_config, true) -- silent mode
+      assert.are.equal(config.default_config.window.position, result.window.position)
+    end)
   end)
 
   describe('refresh validation', function()

--- a/tests/spec/terminal_spec.lua
+++ b/tests/spec/terminal_spec.lua
@@ -290,4 +290,151 @@ describe('terminal module', function()
       assert.is_true(success, 'Force insert mode function should run without error')
     end)
   end)
+
+  describe('floating window', function()
+    local nvim_open_win_called = false
+    local nvim_open_win_config = nil
+    local nvim_create_buf_called = false
+
+    before_each(function()
+      -- Reset tracking variables
+      nvim_open_win_called = false
+      nvim_open_win_config = nil
+      nvim_create_buf_called = false
+
+      -- Mock nvim_open_win to track calls
+      _G.vim.api.nvim_open_win = function(buf, enter, config)
+        nvim_open_win_called = true
+        nvim_open_win_config = config
+        return 123 -- Return a mock window ID
+      end
+
+      -- Mock nvim_create_buf for floating window
+      _G.vim.api.nvim_create_buf = function(listed, scratch)
+        nvim_create_buf_called = true
+        return 43 -- Return a mock buffer ID
+      end
+
+      -- Mock nvim_buf_set_option
+      _G.vim.api.nvim_buf_set_option = function(bufnr, option, value)
+        return true
+      end
+
+      -- Mock nvim_win_set_buf
+      _G.vim.api.nvim_win_set_buf = function(win_id, bufnr)
+        return true
+      end
+
+      -- Mock nvim_buf_set_name
+      _G.vim.api.nvim_buf_set_name = function(bufnr, name)
+        return true
+      end
+
+      -- Mock nvim_win_set_option
+      _G.vim.api.nvim_win_set_option = function(win_id, option, value)
+        return true
+      end
+
+      -- Mock termopen
+      _G.vim.fn.termopen = function(cmd)
+        return 1 -- Return a mock job ID
+      end
+
+      -- Mock vim.o.columns and vim.o.lines for percentage calculations
+      _G.vim.o = {
+        columns = 120,
+        lines = 40
+      }
+    end)
+
+    it('should create floating window when position is "float"', function()
+      -- Claude Code is not running
+      claude_code.claude_code.bufnr = nil
+      
+      -- Configure floating window
+      config.window.position = 'float'
+      config.window.float = {
+        width = 80,
+        height = 20,
+        relative = 'editor',
+        border = 'rounded'
+      }
+
+      -- Call toggle
+      terminal.toggle(claude_code, config, git)
+
+      -- Check that nvim_open_win was called
+      assert.is_true(nvim_open_win_called, 'nvim_open_win should be called for floating window')
+      assert.is_not_nil(nvim_open_win_config, 'floating window config should be provided')
+      assert.are.equal('editor', nvim_open_win_config.relative)
+      assert.are.equal('rounded', nvim_open_win_config.border)
+    end)
+
+    it('should calculate float dimensions from percentages', function()
+      -- Claude Code is not running
+      claude_code.claude_code.bufnr = nil
+      
+      -- Configure floating window with percentage dimensions
+      config.window.position = 'float'
+      config.window.float = {
+        width = '80%',
+        height = '50%',
+        relative = 'editor',
+        border = 'single'
+      }
+
+      -- Call toggle
+      terminal.toggle(claude_code, config, git)
+
+      -- Check that dimensions were calculated correctly
+      assert.is_true(nvim_open_win_called, 'nvim_open_win should be called')
+      assert.are.equal(96, nvim_open_win_config.width) -- 80% of 120
+      assert.are.equal(20, nvim_open_win_config.height) -- 50% of 40
+    end)
+
+    it('should center floating window when position is "center"', function()
+      -- Claude Code is not running
+      claude_code.claude_code.bufnr = nil
+      
+      -- Configure floating window to be centered
+      config.window.position = 'float'
+      config.window.float = {
+        width = 60,
+        height = 20,
+        row = 'center',
+        col = 'center',
+        relative = 'editor'
+      }
+
+      -- Call toggle
+      terminal.toggle(claude_code, config, git)
+
+      -- Check that window is centered
+      assert.is_true(nvim_open_win_called, 'nvim_open_win should be called')
+      assert.are.equal(10, nvim_open_win_config.row) -- (40-20)/2
+      assert.are.equal(30, nvim_open_win_config.col) -- (120-60)/2
+    end)
+
+    it('should reuse existing buffer for floating window when toggling', function()
+      -- Claude Code is already running
+      claude_code.claude_code.bufnr = 42
+      win_ids = {} -- No windows displaying the buffer
+      
+      -- Configure floating window
+      config.window.position = 'float'
+      config.window.float = {
+        width = 80,
+        height = 20,
+        relative = 'editor',
+        border = 'none'
+      }
+
+      -- Call toggle
+      terminal.toggle(claude_code, config, git)
+
+      -- Should open floating window with existing buffer
+      assert.is_true(nvim_open_win_called, 'nvim_open_win should be called')
+      assert.is_false(nvim_create_buf_called, 'should not create new buffer')
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary
- Adds support for displaying claude-code terminal in a floating window
- Adds comprehensive configuration options for float position, size, and border
- Preserves existing split window functionality
- Includes documentation and examples for floating window configuration
- Includes extensive tests for both float and split window modes

## Test plan
- [ ] Open claude-code with floating window: `:ClaudeCode` (with position = "float")
- [ ] Verify floating window appears at configured position with correct size
- [ ] Test percentage-based sizing (e.g., width = "80%", height = "60%")
- [ ] Test centered positioning (row = "center", col = "center")
- [ ] Test different border styles (rounded, single, double, etc.)
- [ ] Verify toggling still works correctly with floating windows
- [ ] Confirm all existing tests pass
- [ ] Test that split window mode still works when float is disabled
- [ ] Verify documentation examples work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)