### PR TITLE
fix: handle NVIM environment variable in test script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,6 +183,20 @@ make test-basic
 make test-config
 ```
 
+### Running Tests from Within Neovim/Claude Code
+
+When running tests from within a Neovim instance (such as when using Claude Code via claude-code.nvim), the test script automatically handles the `$NVIM` environment variable which normally points to a socket file instead of the nvim executable.
+
+The test script will:
+- Use the `$NVIM` variable if it points to a valid executable file
+- Fall back to finding `nvim` in `$PATH` if `$NVIM` points to a socket or invalid path
+- Display which nvim binary is being used for transparency
+
+To verify the NVIM detection logic works correctly, you can run:
+```bash
+./scripts/test_nvim_detection.sh
+```
+
 ### Writing Tests
 
 Tests are written in Lua using a simple BDD-style API:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -188,11 +188,13 @@ make test-config
 When running tests from within a Neovim instance (such as when using Claude Code via claude-code.nvim), the test script automatically handles the `$NVIM` environment variable which normally points to a socket file instead of the nvim executable.
 
 The test script will:
+
 - Use the `$NVIM` variable if it points to a valid executable file
 - Fall back to finding `nvim` in `$PATH` if `$NVIM` points to a socket or invalid path
 - Display which nvim binary is being used for transparency
 
 To verify the NVIM detection logic works correctly, you can run:
+
 ```bash
 ./scripts/test_nvim_detection.sh
 ```

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,8 +18,7 @@ if [ -n "$NVIM" ] && [ -x "$NVIM" ] && [ ! -S "$NVIM" ]; then
   echo "Using NVIM from environment: $NVIM"
 else
   # Find nvim in PATH
-  NVIM=$(which nvim)
-  if [ -z "$NVIM" ]; then
+  if ! NVIM=$(command -v nvim); then
     echo "Error: nvim not found in PATH"
     exit 1
   fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,12 +12,17 @@ cd "$PLUGIN_DIR"
 # Print current directory for debugging
 echo "Running tests from: $(pwd)"
 
-# Find nvim 
-NVIM=${NVIM:-$(which nvim)}
-
-if [ -z "$NVIM" ]; then
-  echo "Error: nvim not found in PATH"
-  exit 1
+# Find nvim - ignore NVIM env var if it points to a socket
+if [ -n "$NVIM" ] && [ -x "$NVIM" ] && [ ! -S "$NVIM" ]; then
+  # NVIM is set and is an executable file (not a socket)
+  echo "Using NVIM from environment: $NVIM"
+else
+  # Find nvim in PATH
+  NVIM=$(which nvim)
+  if [ -z "$NVIM" ]; then
+    echo "Error: nvim not found in PATH"
+    exit 1
+  fi
 fi
 
 echo "Running tests with $NVIM"

--- a/scripts/test_nvim_detection.sh
+++ b/scripts/test_nvim_detection.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Test script to verify NVIM environment variable detection logic
+# This script tests the fix for handling NVIM variable when running inside Neovim
+
+echo "Testing NVIM environment variable detection..."
+
+# Save original NVIM value
+ORIGINAL_NVIM="$NVIM"
+
+# Test 1: NVIM points to a socket (simulating inside Neovim)
+echo "Test 1: NVIM points to a socket"
+export NVIM="/tmp/test_socket"
+mkfifo "$NVIM" 2>/dev/null || true  # Create a named pipe (similar to socket)
+if timeout 5 bash -c 'cd "$(dirname "$0")" && ./scripts/test.sh' 2>&1 | head -10 | grep -q "Running tests with.*nvim"; then
+    echo "✓ Fallback to PATH works"
+else
+    echo "✗ Fallback failed"
+fi
+rm -f "$NVIM"
+
+# Test 2: NVIM points to valid executable
+echo "Test 2: NVIM points to valid executable"
+export NVIM="$(which nvim)"
+if timeout 5 bash -c 'cd "$(dirname "$0")" && ./scripts/test.sh' 2>&1 | head -10 | grep -q "Using NVIM from environment"; then
+    echo "✓ Using provided NVIM works"
+else
+    echo "✗ Using provided NVIM failed"
+fi
+
+# Test 3: NVIM points to non-existent path
+echo "Test 3: NVIM points to non-existent path"
+export NVIM="/nonexistent/nvim"
+if timeout 5 bash -c 'cd "$(dirname "$0")" && ./scripts/test.sh' 2>&1 | head -10 | grep -q "Running tests with.*nvim"; then
+    echo "✓ Fallback from invalid path works"
+else
+    echo "✗ Fallback from invalid path failed"
+fi
+
+# Test 4: NVIM is unset
+echo "Test 4: NVIM is unset"
+unset NVIM
+if timeout 5 bash -c 'cd "$(dirname "$0")" && ./scripts/test.sh' 2>&1 | head -10 | grep -q "Running tests with.*nvim"; then
+    echo "✓ Unset NVIM works"
+else
+    echo "✗ Unset NVIM failed"
+fi
+
+# Restore original NVIM value
+if [ -n "$ORIGINAL_NVIM" ]; then
+  export NVIM="$ORIGINAL_NVIM"
+else
+  unset NVIM
+fi
+
+echo "All NVIM detection tests completed!"


### PR DESCRIPTION
## Summary
- Fixes test script failing when run from within Neovim/Claude Code
- Detects when `$NVIM` points to a socket instead of the nvim executable
- Automatically falls back to finding nvim in PATH when needed

## Problem
When running `make test` from within claude-code.nvim, the test script would fail with permission errors because the `$NVIM` environment variable points to a Neovim socket (e.g., `/run/user/1000/nvim.xxxxx.0`) instead of the actual nvim executable.

## Solution
The test script now checks if `$NVIM` is:
1. A valid executable file → uses it
2. A socket or invalid path → falls back to `which nvim`

## Test plan
- [x] Added `test_nvim_detection.sh` script that verifies all scenarios work correctly
- [x] Tested running `make test` from within claude-code.nvim - now works properly
- [x] Tested running `make test` from regular terminal - continues to work as before
- [x] Added documentation to DEVELOPMENT.md explaining the behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a script to test detection of the Neovim executable, ensuring robust handling of the NVIM environment variable in various scenarios.

- **Documentation**
  - Added detailed instructions on running tests from within Neovim, including explanation of NVIM detection logic and usage of the new test script.

- **Bug Fixes**
  - Improved test script logic to correctly identify and use the appropriate Neovim executable, preventing issues when NVIM points to a socket or invalid path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->