### PR TITLE
Add psql-style editor for Claude prompts

### DIFF
--- a/lua/claude-code/config.lua
+++ b/lua/claude-code/config.lua
@@ -29,14 +29,15 @@ local M = {}
 
 --- ClaudeCodeKeymapsToggle class for toggle keymap configuration
 -- @table ClaudeCodeKeymapsToggle
--- @field normal string|boolean Normal mode keymap for toggling Claude Code, false to disable
--- @field terminal string|boolean Terminal mode keymap for toggling Claude Code, false to disable
+-- @field normal string|false Normal mode keymap for toggling Claude Code, false to disable
+-- @field terminal string|false Terminal mode keymap for toggling Claude Code, false to disable
 
 --- ClaudeCodeKeymaps class for keymap configuration
 -- @table ClaudeCodeKeymaps
 -- @field toggle ClaudeCodeKeymapsToggle Keymaps for toggling Claude Code
 -- @field window_navigation boolean Enable window navigation keymaps
 -- @field scrolling boolean Enable scrolling keymaps
+-- @field scratchpad string|false Normal mode keymap for opening scratchpad editor, false to disable
 
 --- ClaudeCodeCommandVariants class for command variant configuration
 -- @table ClaudeCodeCommandVariants
@@ -117,6 +118,7 @@ M.default_config = {
     },
     window_navigation = true, -- Enable window navigation keymaps (<C-h/j/k/l>)
     scrolling = true, -- Enable scrolling keymaps (<C-f/b>) for page up/down
+    scratchpad = '<leader>ce', -- Normal mode keymap for opening scratchpad editor
   },
 }
 
@@ -274,6 +276,10 @@ local function validate_config(config)
 
   if type(config.keymaps.scrolling) ~= 'boolean' then
     return false, 'keymaps.scrolling must be a boolean'
+  end
+
+  if not (config.keymaps.scratchpad == false or type(config.keymaps.scratchpad) == 'string') then
+    return false, 'keymaps.scratchpad must be a string or false'
   end
 
   return true, nil

--- a/lua/claude-code/keymaps.lua
+++ b/lua/claude-code/keymaps.lua
@@ -52,6 +52,16 @@ function M.register_keymaps(claude_code, config)
     end
   end
 
+  -- Register scratchpad keymap if configured
+  if config.keymaps.scratchpad then
+    vim.api.nvim_set_keymap(
+      'n',
+      config.keymaps.scratchpad,
+      [[<cmd>lua require('claude-code.scratchpad').open_editor()<CR>]],
+      vim.tbl_extend('force', map_opts, { desc = 'Claude Code: Edit in scratchpad' })
+    )
+  end
+
   -- Register with which-key if it's available
   vim.defer_fn(function()
     local status_ok, which_key = pcall(require, 'which-key')
@@ -80,6 +90,14 @@ function M.register_keymaps(claude_code, config)
             }
           end
         end
+      end
+
+      -- Register scratchpad keymap with which-key
+      if config.keymaps.scratchpad then
+        which_key.add {
+          mode = 'n',
+          { config.keymaps.scratchpad, desc = 'Claude Code: Edit in scratchpad', icon = '✏️' },
+        }
       end
     end
   end, 100)

--- a/lua/claude-code/scratchpad.lua
+++ b/lua/claude-code/scratchpad.lua
@@ -28,6 +28,9 @@ function M.open_editor()
   vim.bo[edit_buf].bufhidden = 'wipe'   -- Clean up when window closes
   vim.bo[edit_buf].filetype = 'markdown'
   vim.api.nvim_buf_set_name(edit_buf, 'claude://scratchpad_message')
+  
+  -- Enable word wrap for the scratchpad
+  vim.cmd('set wrap')
 
   -- Store terminal window ID - this is how we know where to send text
   vim.b._claude_target_win = term_win

--- a/lua/claude-code/scratchpad.lua
+++ b/lua/claude-code/scratchpad.lua
@@ -1,0 +1,75 @@
+-- Psql-style scratchpad for the claude-code.nvim terminal
+local M = {}
+
+-- Check if current buffer is a Claude Code terminal
+local function is_current_claude_term()
+  local buf = vim.api.nvim_get_current_buf()
+  return vim.bo[buf].buftype == 'terminal'
+         and vim.api.nvim_buf_get_name(buf):match('claude%-code') ~= nil
+end
+
+-- Open a vim buffer for editing Claude input. Only works from Claude terminal.
+function M.open_editor()
+  if not is_current_claude_term() then
+    vim.notify('Claude Code terminal must be focused to open editor', vim.log.levels.INFO)
+    return
+  end
+
+  -- Capture the terminal window we'll send text to later
+  local term_win = vim.api.nvim_get_current_win()
+
+  -- Create a new vertical split on the left (80 columns)
+  vim.cmd('topleft vertical 80vnew')
+  local edit_buf = vim.api.nvim_get_current_buf()
+
+  -- Set up the scratch buffer
+  vim.bo[edit_buf].buftype = 'acwrite'  -- Custom write handling
+  vim.bo[edit_buf].swapfile = false
+  vim.bo[edit_buf].bufhidden = 'wipe'   -- Clean up when window closes
+  vim.bo[edit_buf].filetype = 'markdown'
+  vim.api.nvim_buf_set_name(edit_buf, 'claude://scratchpad_message')
+
+  -- Store terminal window ID - this is how we know where to send text
+  vim.b._claude_target_win = term_win
+
+  -- Start in insert mode for immediate typing
+  vim.cmd('startinsert')
+  
+  -- Handle save events (both :w and :wq)
+  vim.api.nvim_create_augroup('ClaudeCodeScratchpad', { clear = false })
+  vim.api.nvim_create_autocmd('BufWriteCmd', {
+    group = 'ClaudeCodeScratchpad',
+    buffer = edit_buf,
+    callback = function(args)
+      -- Get the terminal window we stored earlier
+      local tgt_win = vim.b._claude_target_win
+      if not vim.api.nvim_win_is_valid(tgt_win) then
+        vim.notify('Original Claude window vanished', vim.log.levels.ERROR)
+        return
+      end
+
+      -- Get the terminal's channel ID for sending text
+      local term_buf = vim.api.nvim_win_get_buf(tgt_win)
+      local ok, chan = pcall(vim.api.nvim_buf_get_var, term_buf, 'terminal_job_id')
+      if not ok or not tonumber(chan) or tonumber(chan) == 0 then
+        vim.notify('Could not get channel ID for Claude terminal', vim.log.levels.ERROR)
+        return
+      end
+
+      -- Collect all lines and join with newlines
+      local text = table.concat(vim.api.nvim_buf_get_lines(args.buf, 0, -1, false), '\n')
+      
+      -- Send text to the terminal
+      local ok, err = pcall(vim.api.nvim_chan_send, chan, text)
+      if not ok then
+        vim.notify('Send failed: ' .. tostring(err), vim.log.levels.ERROR)
+        return
+      end
+
+      -- Mark buffer as saved so :wq works correctly
+      vim.bo[args.buf].modified = false
+    end,
+  })
+end
+
+return M


### PR DESCRIPTION
Opens a proper Neovim buffer for composing messages to Claude, similar to psql's `\e` command. Enables multi-line editing with full editor capabilities instead of terminal input limitations. Access via `<leader>ce`, send to Claude with `:w` or `:wq`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a scratchpad feature for composing and sending multi-line input to the Claude Code terminal.
  - Added a configurable keymap for quick access to the scratchpad in normal mode.
- **Documentation**
  - Clarified keymap configuration to specify accepted value types for normal, terminal, and scratchpad keymaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->