### PR TITLE
Fix failing git pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,22 +27,22 @@ STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.lua$
 
 if [ -n "$STAGED_FILES" ]; then
   echo "Running StyLua on staged Lua files..."
-  
+
   # Format all staged Lua files
   for FILE in $STAGED_FILES; do
     stylua "$FILE"
     git add "$FILE"
   done
-  
+
   echo "Lua files have been formatted and staged."
-  
+
   # Run luacheck if available
   if [ "$HAS_LUACHECK" -eq 1 ]; then
     echo "Running luacheck on staged Lua files..."
     LINT_ISSUES=0
     FIXABLE_ISSUES=0
     FIXED_FILES=""
-    
+
     # First check for issues that we can automatically fix
     for FILE in $STAGED_FILES; do
       # Auto-fix trailing whitespace
@@ -51,7 +51,7 @@ if [ -n "$STAGED_FILES" ]; then
         FIXABLE_ISSUES=1
         FIXED_FILES="$FIXED_FILES $FILE"
       fi
-      
+
       # Auto-fix line endings (ensure LF)
       if file "$FILE" | grep -q "CRLF"; then
         dos2unix "$FILE" 2>/dev/null
@@ -59,7 +59,7 @@ if [ -n "$STAGED_FILES" ]; then
         FIXED_FILES="$FIXED_FILES $FILE"
       fi
     done
-    
+
     # If we fixed any issues, add them back to staging
     if [ "$FIXABLE_ISSUES" -eq 1 ]; then
       echo "Fixed some linting issues automatically in:$FIXED_FILES"
@@ -67,7 +67,7 @@ if [ -n "$STAGED_FILES" ]; then
         git add "$FILE"
       done
     fi
-    
+
     # Now run the full luacheck to see if there are remaining issues
     for FILE in $STAGED_FILES; do
       luacheck "$FILE"
@@ -75,7 +75,7 @@ if [ -n "$STAGED_FILES" ]; then
         LINT_ISSUES=1
       fi
     done
-    
+
     if [ "$LINT_ISSUES" -eq 1 ]; then
       echo "Error: Lua lint issues found that couldn't be fixed automatically."
       echo "Please fix the remaining issues before committing."
@@ -83,28 +83,28 @@ if [ -n "$STAGED_FILES" ]; then
       exit 1
     fi
   fi
-  
+
   # ======== Run Tests ========
   echo "Running tests to ensure code quality..."
-  
+
   # Find the project root directory (where .git is)
   PROJECT_ROOT=$(git rev-parse --show-toplevel)
-  
+
   # Change to the project root
   cd "$PROJECT_ROOT" || exit 1
-  
+
   # Run the tests directly using a specific path
-  FULL_PATH="/home/gregg/Projects/neovim/plugins/claude-code/scripts/test.sh"
-  echo "Running test script at: $FULL_PATH"
-  bash "$FULL_PATH"
-  
+  RELATIVE_PATH="scripts/test.sh"
+  echo "Running test script at: $RELATIVE_PATH"
+  bash "$RELATIVE_PATH"
+
   # Check if tests passed
   if [ $? -ne 0 ]; then
     echo "❌ Tests failed! Commit aborted."
     echo "Please fix the test failures before committing."
     exit 1
   fi
-  
+
   echo "✅ All tests passed. Proceeding with commit."
 fi
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an issue which prevents the git `pre-commit` hook from succeeding. This is due to the hardcoded path to the ` `scripts/test.sh` script.

### Before

Without this change the git pre-commit hook would always fail due to the invalid hardcoded path to the `test.sh` script.

```
$ git commit -m'address the rabbit reviews 🥕'
Running StyLua on staged Lua files...
Lua files have been formatted and staged.
Running luacheck on staged Lua files...
Checking lua/claude-code/config.lua               OK

Total: 0 warnings / 0 errors in 1 file
Checking lua/claude-code/keymaps.lua              OK

Total: 0 warnings / 0 errors in 1 file
Running tests to ensure code quality...
Running test script at: /home/gregg/Projects/neovim/plugins/claude-code/scripts/test.sh
bash: /home/gregg/Projects/neovim/plugins/claude-code/scripts/test.sh: No such file or directory
❌ Tests failed! Commit aborted.
Please fix the test failures before committing.
```

### After

```
$ git commit -m'address the rabbit reviews 🥕'
Running StyLua on staged Lua files...
Lua files have been formatted and staged.
Running luacheck on staged Lua files...
Checking lua/claude-code/config.lua               OK

Total: 0 warnings / 0 errors in 1 file
Checking lua/claude-code/keymaps.lua              OK

Total: 0 warnings / 0 errors in 1 file
Running tests to ensure code quality...
Running test script at: /home/some/path/claude-code.nvim/scripts/test.sh
Changing to plugin directory: /home/some/path/claude-code.nvim
Running tests from: /home/some/path/claude-code.nvim
Running tests with /usr/bin/nvim
Running tests with a 60 second timeout...
[ ... removed lines ... ]
Running tests in: version_spec.lua
Success ||      version string should return the correct version string
Success ||      version version components should have correct version components
Success ||      version print_version should call vim.notify with correct message

==== Test Results ====
Total Tests Run: 67
Successes: 67
Failures: 0
Errors: 0
=====================

All tests passed!
Test run completed successfully
✅ All tests passed. Proceeding with commit.
[window-navigation-keymap b32bd39] address the rabbit reviews 🥕
 2 files changed, 7 insertions(+), 7 deletions(-)
```

## Type of Change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

Please check all that apply:

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested with the actual Claude Code CLI tool
- [ ] I have tested in different environments (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit hook to run the test script via a relative path, improving portability across different environments and directory setups.
  - Maintains existing test behavior, error handling, and success messaging.
  - Minor whitespace cleanups in the hook script; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->