### PR TITLE
Fix terminal cleanup when Claude process exits

### DIFF
--- a/lua/claude-code/file_refresh.lua
+++ b/lua/claude-code/file_refresh.lua
@@ -96,17 +96,32 @@ function M.setup(claude_code, config)
     desc = 'Set shorter updatetime when Claude Code is open',
   })
 
-  -- When Claude Code closes, restore normal updatetime
+  -- When Claude Code closes, restore normal updatetime and clean up
   vim.api.nvim_create_autocmd('TermClose', {
     group = augroup,
     pattern = '*',
-    callback = function()
-      local buf_name = vim.api.nvim_buf_get_name(0)
-      if buf_name:match('claude%-code$') then
+    callback = function(args)
+      local buf_name = vim.api.nvim_buf_get_name(args.buf)
+      if buf_name:match('claude%-code') then
         vim.o.updatetime = claude_code.claude_code.saved_updatetime
+        -- Clean up instance tracking and close window
+        for instance_id, bufnr in pairs(claude_code.claude_code.instances) do
+          if bufnr == args.buf then
+            claude_code.claude_code.instances[instance_id] = nil
+            break
+          end
+        end
+        -- Close windows and delete buffer after a short delay to allow TermClose to complete
+        vim.schedule(function()
+          local win_ids = vim.fn.win_findbuf(args.buf)
+          for _, win_id in ipairs(win_ids) do
+            pcall(vim.api.nvim_win_close, win_id, true)
+          end
+          pcall(vim.api.nvim_buf_delete, args.buf, { force = true })
+        end)
       end
     end,
-    desc = 'Restore normal updatetime when Claude Code is closed',
+    desc = 'Restore normal updatetime and clean up when Claude Code is closed',
   })
 end
 

--- a/lua/claude-code/terminal.lua
+++ b/lua/claude-code/terminal.lua
@@ -394,7 +394,14 @@ function M.toggle(claude_code, config, git)
 
   -- Validate existing buffer
   if bufnr and not is_valid_terminal_buffer(bufnr) then
-    -- Buffer is no longer a valid terminal, reset
+    -- Buffer is no longer a valid terminal, clean up and reset
+    -- Close any windows showing this buffer
+    local win_ids = vim.fn.win_findbuf(bufnr)
+    for _, win_id in ipairs(win_ids) do
+      pcall(vim.api.nvim_win_close, win_id, true)
+    end
+    -- Delete the old buffer to free up the name
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
     claude_code.claude_code.instances[instance_id] = nil
     bufnr = nil
   end


### PR DESCRIPTION
## Summary

Noticed this when running with a floating window.

Fixes two issues when the Claude process exits (via ctrl-c, ctrl-d, or pressing Enter after "Process exited"):

1. **"E95: Buffer with this name already exists" error on toggle** - When toggling after the process had exited, `is_valid_terminal_buffer()` correctly detected the dead terminal and cleared the instance reference, but the old buffer wasn't deleted. The new instance then failed when trying to use the same buffer name.

2. **Empty floating window lingers after exit** - Pressing Enter after "Process exited" would close the terminal job but leave the floating window open with an empty buffer.

## Changes

- **terminal.lua**: In `toggle()`, when detecting a dead terminal buffer, close any windows showing it and delete the buffer before creating a new instance.

- **file_refresh.lua**: In `TermClose` autocmd, clean up instance tracking, close the floating window, and delete the buffer.

## Test plan

- [ ] Open Claude with `:ClaudeCode` in floating window mode
- [ ] Exit with ctrl-d until "Process exited 0" appears
- [ ] Press ctrl+' (or toggle key) - should open a fresh Claude instance without error
- [ ] Open Claude again, exit with ctrl-d, then press Enter - floating window should close automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal buffer cleanup on closure, ensuring proper restoration of editor settings.
  * Enhanced handling of invalid terminal buffers with more aggressive UI cleanup, closing associated windows and freeing buffer resources.
  * Better resource management for terminal sessions to prevent orphaned windows and buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->